### PR TITLE
Don't try to return results if not available (OpenSiteExplorer)

### DIFF
--- a/src/modules/seostats.opensiteexplorer.php
+++ b/src/modules/seostats.opensiteexplorer.php
@@ -23,12 +23,14 @@ class SEOstats_OpenSiteExplorer extends SEOstats implements services
 		
 		$data = $doc->getElementsByTagName('td');
 
-        return array(
-			'domainAuthority'    => trim(strip_tags($data->item(0)->textContent)),
-            'pageAuthority'      => trim(strip_tags($data->item(1)->textContent)),          
-            'linkingRootDomains' => trim(strip_tags($data->item(2)->textContent)),
-            'totalInboundLinks'  => trim(strip_tags($data->item(3)->textContent))
-        );
+        if($data->item(0)){ // Only return results if available
+            return array(
+                'domainAuthority'    => trim(strip_tags($data->item(0)->textContent)),
+                'pageAuthority'      => trim(strip_tags($data->item(1)->textContent)),          
+                'linkingRootDomains' => trim(strip_tags($data->item(2)->textContent)),
+                'totalInboundLinks'  => trim(strip_tags($data->item(3)->textContent))
+            );
+        }
     }
 }
 


### PR DESCRIPTION
I was getting a PHP notice since I had used more than the allowed number of reports in a day. This is a quick hack to prevent that behavior. I should mention that it doesn't currently alert the user of the issue.
