### PR TITLE
Pagespeed v2 patch

### DIFF
--- a/SEOstats/Config/Services.php
+++ b/SEOstats/Config/Services.php
@@ -41,7 +41,7 @@ interface Services
     const GOOGLE_APISEARCH_URL = 'http://ajax.googleapis.com/ajax/services/search/web?v=1.0&rsz=%s&q=%s';
 
     // Google Pagespeed Insights API Endpoint.
-    const GOOGLE_PAGESPEED_URL = 'https://www.googleapis.com/pagespeedonline/v1/runPagespeed?url=%s&key=%s';
+    const GOOGLE_PAGESPEED_URL = 'https://www.googleapis.com/pagespeedonline/v2/runPagespeed?url=%s&strategy=%s&key=%s';
 
     // Google +1 Fastbutton URL.
     const GOOGLE_PLUSONE_URL = 'https://plusone.google.com/u/0/_/+1/fastbutton?count=true&url=%s';

--- a/SEOstats/Services/Google.php
+++ b/SEOstats/Services/Google.php
@@ -108,8 +108,8 @@ class Google extends SEOstats
         $url = parent::getUrl($url);
         $ret = self::getPagespeedAnalysis($url, $strategy);
 
-        return !isset($ret->score) || !$ret->score ? parent::noDataDefaultValue() :
-            intval($ret->score);
+        return !isset($ret->ruleGroups->SPEED->score) || !$ret->ruleGroups->SPEED->score ? parent::noDataDefaultValue() :
+            intval($ret->ruleGroups->SPEED->score);
     }
 
     /**

--- a/SEOstats/Services/Google.php
+++ b/SEOstats/Services/Google.php
@@ -108,8 +108,14 @@ class Google extends SEOstats
         $url = parent::getUrl($url);
         $ret = self::getPagespeedAnalysis($url, $strategy);
 
-        return !isset($ret->ruleGroups->SPEED->score) || !$ret->ruleGroups->SPEED->score ? parent::noDataDefaultValue() :
-            intval($ret->ruleGroups->SPEED->score);
+        // Check if $ret->score exists for backwards compatibility with v1.
+        if (!isset($ret->score)) {
+            return !isset($ret->ruleGroups->SPEED->score) || !$ret->ruleGroups->SPEED->score ? parent::noDataDefaultValue() :
+                intval($ret->ruleGroups->SPEED->score);
+        }
+        else {
+            return $ret->score;
+        }
     }
 
     /**

--- a/SEOstats/Services/Google.php
+++ b/SEOstats/Services/Google.php
@@ -86,7 +86,7 @@ class Google extends SEOstats
                : intval($obj->responseData->cursor->estimatedResultCount);
     }
 
-    public static function getPagespeedAnalysis($url = false)
+    public static function getPagespeedAnalysis($url = false, $strategy = 'desktop')
     {
         if ('' == Config\ApiKeys::GOOGLE_SIMPLE_API_ACCESS_KEY) {
             throw new E('In order to use the PageSpeed API, you must obtain
@@ -96,17 +96,17 @@ class Google extends SEOstats
 
         $url = parent::getUrl($url);
         $url = sprintf(Config\Services::GOOGLE_PAGESPEED_URL,
-            $url, Config\ApiKeys::GOOGLE_SIMPLE_API_ACCESS_KEY);
+            $url, $strategy, Config\ApiKeys::GOOGLE_SIMPLE_API_ACCESS_KEY);
 
         $ret = static::_getPage($url);
 
         return Helper\Json::decode($ret);
     }
 
-    public static function getPagespeedScore($url = false)
+    public static function getPagespeedScore($url = false, $strategy = 'desktop')
     {
         $url = parent::getUrl($url);
-        $ret = self::getPagespeedAnalysis($url);
+        $ret = self::getPagespeedAnalysis($url, $strategy);
 
         return !isset($ret->score) || !$ret->score ? parent::noDataDefaultValue() :
             intval($ret->score);


### PR DESCRIPTION
Upgrade to PageSpeed Insights API v2 (as opposed to v1) and implement support for the 'strategy' query string which can be set as either 'desktop' or 'mobile' depending upon whether you want the mobile pagespeed data or desktop pagespeed data. 