### PR TITLE
Create .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,9 +1,8 @@
 * text=auto
-
-tests/SEOstatsTest/_assert/* linguist-vendored
-
-/tests export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore
 .scrutinizer.yml export-ignore
 .travis.yml export-ignore
+/example export-ignore
+/tests export-ignore
+/tests/SEOstatsTest/_assert/* linguist-vendored

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+* text=auto
+
+tests/SEOstatsTest/_assert/* linguist-vendored
+
+/tests export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+.scrutinizer.yml export-ignore
+.travis.yml export-ignore


### PR DESCRIPTION
This should do 2 things:
 - Exclude the _assert directory for language statistics, so hopefully will mark this as a PHP library (instead of HTML) See https://github.com/github/linguist#overrides
- Export the tests directory when stable zip releases are downloaded with Composer, to save space/bandwidth. With `--prefer-source` they are still downloaded.

Not 100% sure of the language override is completely correct, but I hope so :)