### PR TITLE
#98 Allow Using DotEnv for ApiKeys

### DIFF
--- a/SEOstats/Config/ApiKeys.php
+++ b/SEOstats/Config/ApiKeys.php
@@ -15,7 +15,7 @@ namespace SEOstats\Config;
  * Client API keys
  * @package    SEOstats
  */
-interface ApiKeys
+class ApiKeys
 {
     // To acquire an API key, visit Google's APIs Console here:
     //      https://code.google.com/apis/console
@@ -32,4 +32,22 @@ interface ApiKeys
     // To acquire a SISTRIX API key, visit:
     //      http://www.sistrix.de
     const SISTRIX_API_ACCESS_KEY = '';
+
+    public static function getGoogleSimpleApiAccessKey() {
+        return env('GOOGLE_SIMPLE_API_ACCESS_KEY', self::GOOGLE_SIMPLE_API_ACCESS_KEY);
+    }
+
+    public static function getMozscapeAccessId() {
+        return env('MOZSCAPE_ACCESS_ID', self::MOZSCAPE_ACCESS_ID);
+    }
+
+    public static function getMozscapeSecretKey()
+    {
+        return env('MOZSCAPE_SECRET_KEY', self::MOZSCAPE_SECRET_KEY);
+    }
+
+    public static function getSistrixApiAccessKey()
+    {
+        return env('SISTRIX_API_ACCESS_KEY', self::SISTRIX_API_ACCESS_KEY);
+    }
 }

--- a/SEOstats/Services/Google.php
+++ b/SEOstats/Services/Google.php
@@ -88,7 +88,7 @@ class Google extends SEOstats
 
     public static function getPagespeedAnalysis($url = false, $strategy = 'desktop')
     {
-        if ('' == Config\ApiKeys::GOOGLE_SIMPLE_API_ACCESS_KEY) {
+        if ('' == Config\ApiKeys::getGoogleSimpleApiAccessKey()) {
             throw new E('In order to use the PageSpeed API, you must obtain
                 and set an API key first (see SEOstats\Config\ApiKeys.php).');
             exit(0);
@@ -96,7 +96,7 @@ class Google extends SEOstats
 
         $url = parent::getUrl($url);
         $url = sprintf(Config\Services::GOOGLE_PAGESPEED_URL,
-            $url, $strategy, Config\ApiKeys::GOOGLE_SIMPLE_API_ACCESS_KEY);
+            $url, $strategy, Config\ApiKeys::getGoogleSimpleApiAccessKey());
 
         $ret = static::_getPage($url);
 

--- a/SEOstats/Services/Mozscape.php
+++ b/SEOstats/Services/Mozscape.php
@@ -78,8 +78,8 @@ class Mozscape extends SEOstats
      */
     public static function getCols($cols, $url = false)
     {
-        if ('' == Config\ApiKeys::MOZSCAPE_ACCESS_ID ||
-            '' == Config\ApiKeys::MOZSCAPE_SECRET_KEY) {
+        if ('' == Config\ApiKeys::getMozscapeAccessId() ||
+            '' == Config\ApiKeys::getMozscapeSecretKey()) {
             throw new E('In order to use the Mozscape API, you must obtain
                 and set an API key first (see SEOstats\Config\ApiKeys.php).');
             exit(0);
@@ -90,7 +90,7 @@ class Mozscape extends SEOstats
         $apiEndpoint = sprintf(Config\Services::MOZSCAPE_API_URL,
             urlencode(Helper\Url::parseHost(parent::getUrl($url))),
             $cols,
-            Config\ApiKeys::MOZSCAPE_ACCESS_ID,
+            Config\ApiKeys::getMozscapeAccessId(),
             $expires,
             urlencode(self::_getUrlSafeSignature($expires))
         );
@@ -104,8 +104,8 @@ class Mozscape extends SEOstats
 
     private static function _getUrlSafeSignature($expires)
     {
-        $data = Config\ApiKeys::MOZSCAPE_ACCESS_ID . "\n{$expires}";
-        $sig  = self::_hmacsha1($data, Config\ApiKeys::MOZSCAPE_SECRET_KEY);
+        $data = Config\ApiKeys::getMozscapeAccessId() . "\n{$expires}";
+        $sig  = self::_hmacsha1($data, Config\ApiKeys::getMozscapeSecretKey());
 
         return base64_encode($sig);
     }

--- a/SEOstats/Services/Sistrix.php
+++ b/SEOstats/Services/Sistrix.php
@@ -69,7 +69,7 @@ class Sistrix extends SEOstats
         $domain = static::getDomainFromUrl($url);
         $database = static::getValidDatabase($db);
 
-        $dataUrl = sprintf(Config\Services::SISTRIX_API_VI_URL, Config\ApiKeys::SISTRIX_API_ACCESS_KEY, urlencode($domain), $database);
+        $dataUrl = sprintf(Config\Services::SISTRIX_API_VI_URL, Config\ApiKeys::getSistrixApiAccessKey(), urlencode($domain), $database);
 
         $json = static::_getPage($dataUrl);
 
@@ -88,7 +88,7 @@ class Sistrix extends SEOstats
     {
         self::guardApiKey();
 
-        $dataUrl = sprintf(Config\Services::SISTRIX_API_CREDITS_URL, Config\ApiKeys::SISTRIX_API_ACCESS_KEY);
+        $dataUrl = sprintf(Config\Services::SISTRIX_API_CREDITS_URL, Config\ApiKeys::getSistrixApiAccessKey());
         $json = static::_getPage($dataUrl);
 
         if(empty($json)) {
@@ -117,7 +117,7 @@ class Sistrix extends SEOstats
 
     protected static function hasApiKey()
     {
-        if ('' == Config\ApiKeys::SISTRIX_API_ACCESS_KEY) {
+        if ('' == Config\ApiKeys::getSistrixApiAccessKey()) {
             return false;
         }
 

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,8 @@
 	"require" : {
 		"php" : ">=5.3",
 		"ext-curl" : "*",
-		"ext-json" : "*"
+		"ext-json" : "*",
+		"vlucas/phpdotenv" : "*"
 	},
     "require-dev" : {
 				"squizlabs/php_codesniffer" : "~1",


### PR DESCRIPTION
In order to be able to store configuration for a project without touching the code inside vendor
 we added the dotenv dependency and fetch the keys from the ENV if existing.

 The configuration constants can still be used.
