### PR TITLE
Enable automatic filtering

### DIFF
--- a/SEOstats/Services/Google/Search.php
+++ b/SEOstats/Services/Google/Search.php
@@ -100,8 +100,8 @@ class Search extends SEOstats
     protected static function getNextSerp ($start, $query)
     {
         return 0 == $start
-            ? sprintf('search?q=%s&filter=0', $query)
-            : sprintf('search?q=%s&filter=0&start=%s0', $query, $start);
+            ? sprintf('search?q=%s&filter=1', $query)
+            : sprintf('search?q=%s&filter=1&start=%s0', $query, $start);
     }
 
     protected static function guardNoCaptcha ($response)


### PR DESCRIPTION
Adding `filter=0` to the request for Google will disable automatic filtering as explained here: https://support.google.com/gsa/answer/2672256?hl=en. By default, automatic filtering is enabled - not disabled, so it probably makes sense to have automatic filtering enabled, not disabled. Having it disabled means you may see one domain appear multiple times in the search results.