### PR TITLE
Move `tests/` to autoload-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,12 +43,17 @@
     },
 	"autoload" : {
 		"psr-0" : {
-			"SEOstats\\" : ""
+			"SEOstats\\" : "SEOstats/"
 		},
 		"classmap" : [
 			"SEOstats/Services/3rdparty"
 		]
 	},
+    "autoload-dev" : {
+        "psr-0" : {
+			"SEOstatsTest\\" : "tests/SEOstatsTest/"
+		}
+    },
     "extra": {
         "branch-alias": {
 			"dev-master": "2.5-dev"


### PR DESCRIPTION
`tests/` should not be exposed to users of the library, so it should be moved to `autoload-dev`. I also found there were two `SEOstatsTest\AbstractServiceTestCase` classes defined. Maybe this should also be fixed.